### PR TITLE
F Lock PMR446

### DIFF
--- a/frequencies.c
+++ b/frequencies.c
@@ -208,6 +208,11 @@ int TX_freq_check(const uint32_t Frequency)
 				return 0;
 			break;
 
+		case F_LOCK_PMR:
+			if (Frequency >= 44600625 && Frequency <= 44619375)
+				return 0;
+			break;
+
 		case F_LOCK_ALL:
 			break;
 	}

--- a/settings.h
+++ b/settings.h
@@ -46,6 +46,7 @@ enum {
 	F_LOCK_GB,
 	F_LOCK_430,
 	F_LOCK_438,
+	F_LOCK_PMR,
 	F_LOCK_ALL,	// disable TX on all frequencies, scanner mode
 	F_LOCK_LEN
 };

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -305,6 +305,7 @@ const char * const gSubMenu_F_LOCK[] =
 	"GB HAM\n144-148\n430-440",
 	"137-174\n400-430",
 	"137-174\n400-438",
+	"PMR446",
 	"DISABLE\nALL"
 };
 


### PR DESCRIPTION
Add submenu to F Lock. Limit TX to PMR446 frequencies (44600625 - 4619375).