### PR TITLE
Fix compiler error when setting ENABLE_PWRON_PASSWORD = 0

### DIFF
--- a/board.c
+++ b/board.c
@@ -65,10 +65,10 @@ static const uint32_t gDefaultFrequencyTable[] =
 		FLASH_Init(FLASH_READ_MODE_1_CYCLE);
 		FLASH_ConfigureTrimValues();
 		SYSTEM_ConfigureClocks();
-	
+
 		overlay_FLASH_MainClock       = 48000000;
 		overlay_FLASH_ClockMultiplier = 48;
-	
+
 		FLASH_Init(FLASH_READ_MODE_2_CYCLE);
 	}
 #endif
@@ -606,7 +606,7 @@ void BOARD_EEPROM_Init(void)
 		gEeprom.ALARM_MODE                 = (Data[0] <  2) ? Data[0] : true;
 	#endif
 	gEeprom.ROGER                          = (Data[1] <  3) ? Data[1] : ROGER_MODE_OFF;
-	// Data[2] empty slot 
+	// Data[2] empty slot
 	gEeprom.TX_VFO                         = (Data[3] <  2) ? Data[3] : 0;
 	gEeprom.BATTERY_TYPE                   = (Data[4] < BATTERY_TYPE_UNKNOWN) ? Data[4] : BATTERY_TYPE_1600_MAH;
 	gEeprom.SQL_TONE                       = (Data[5] <  ARRAY_SIZE(CTCSS_Options)) ? Data[5] : 50;
@@ -619,7 +619,7 @@ void BOARD_EEPROM_Init(void)
 	gEeprom.DTMF_GROUP_CALL_CODE         = DTMF_ValidateCodes((char *)(Data + 2), 1) ? Data[2] : '#';
 	gEeprom.DTMF_DECODE_RESPONSE         = (Data[3] <   4) ? Data[3] : 0;
 	gEeprom.DTMF_auto_reset_time         = (Data[4] <  61) ? Data[4] : (Data[4] >= 5) ? Data[4] : 10;
-#endif		
+#endif
 	gEeprom.DTMF_PRELOAD_TIME            = (Data[5] < 101) ? Data[5] * 10 : 300;
 	gEeprom.DTMF_FIRST_CODE_PERSIST_TIME = (Data[6] < 101) ? Data[6] * 10 : 100;
 	gEeprom.DTMF_HASH_CODE_PERSIST_TIME  = (Data[7] < 101) ? Data[7] * 10 : 100;
@@ -652,7 +652,7 @@ void BOARD_EEPROM_Init(void)
 		memset(gEeprom.KILL_CODE, 0, sizeof(gEeprom.KILL_CODE));
 		strcpy(gEeprom.KILL_CODE, "ABCD9");
 	}
-	
+
 	// 0EF0..0EF7
 	EEPROM_ReadBuffer(0x0EF0, Data, 8);
 	if (DTMF_ValidateCodes((char *)Data, 8))
@@ -673,7 +673,7 @@ void BOARD_EEPROM_Init(void)
 		memset(gEeprom.DTMF_UP_CODE, 0, sizeof(gEeprom.DTMF_UP_CODE));
 		strcpy(gEeprom.DTMF_UP_CODE, "12345");
 	}
-	
+
 	// 0F08..0F17
 	EEPROM_ReadBuffer(0x0F08, Data, 16);
 	if (DTMF_ValidateCodes((char *)Data, 16))
@@ -683,7 +683,7 @@ void BOARD_EEPROM_Init(void)
 		memset(gEeprom.DTMF_DOWN_CODE, 0, sizeof(gEeprom.DTMF_DOWN_CODE));
 		strcpy(gEeprom.DTMF_DOWN_CODE, "54321");
 	}
-	
+
 	// 0F18..0F1F
 	EEPROM_ReadBuffer(0x0F18, Data, 8);
 //	gEeprom.SCAN_LIST_DEFAULT = (Data[0] < 2) ? Data[0] : false;
@@ -716,7 +716,7 @@ void BOARD_EEPROM_Init(void)
     memmove(&gEeprom.RX_OFFSET, Data, 4);
 	// Make sure it inits with some sane value
 	gEeprom.RX_OFFSET = gEeprom.RX_OFFSET > RX_OFFSET_MAX ? 0 : gEeprom.RX_OFFSET;
-	
+
 	if (!gEeprom.VFO_OPEN)
 	{
 		gEeprom.ScreenChannel[0] = gEeprom.MrChannel[0];
@@ -730,7 +730,7 @@ void BOARD_EEPROM_Init(void)
 		if(att->__val == 0xff){
 			att->__val = 0;
 			att->band = 0xf;
-		}	
+		}
 	}
 	#ifdef ENABLE_ENCRYPTION
 		// 0F30..0F3F - load encryption key
@@ -740,18 +740,18 @@ void BOARD_EEPROM_Init(void)
 	#ifdef ENABLE_SPECTRUM_SHOW_CHANNEL_NAME
 		BOARD_gMR_LoadChannels();
 	#endif
-	
+
 }
 #ifdef ENABLE_SPECTRUM_SHOW_CHANNEL_NAME
 // Load channel frequencies, names into global memory lookup table
 void BOARD_gMR_LoadChannels() {
 	uint8_t  i;
 	uint32_t freq_buf;
-	
+
 	for (i = MR_CHANNEL_FIRST; i <= MR_CHANNEL_LAST; i++)
 	{
 		freq_buf = BOARD_fetchChannelFrequency(i);
-		
+
 		gMR_ChannelFrequencyAttributes[i].Frequency = RX_freq_check(freq_buf) == -1 ? 0 : freq_buf;
 		SETTINGS_FetchChannelName(gMR_ChannelFrequencyAttributes[i].Name, i);
 	}
@@ -784,7 +784,7 @@ void BOARD_EEPROM_LoadCalibration(void)
 		gEeprom.VOX1_THRESHOLD = 205-(20*gEeprom.VOX_LEVEL);
 		gEeprom.VOX0_THRESHOLD = 215-(20*gEeprom.VOX_LEVEL);
 	#endif
-	
+
 	//EEPROM_ReadBuffer(0x1F80 + gEeprom.MIC_SENSITIVITY, &Mic, 1);
 	//gEeprom.MIC_SENSITIVITY_TUNING = (Mic < 32) ? Mic : 15;
 	gEeprom.MIC_SENSITIVITY_TUNING = gMicGain_dB2[gEeprom.MIC_SENSITIVITY];
@@ -823,7 +823,7 @@ uint32_t BOARD_fetchChannelFrequency(const int channel)
 	} __attribute__((packed)) info;
 
 	EEPROM_ReadBuffer(channel * 16, &info, sizeof(info));
-	
+
 	return info.frequency;
 }
 #ifdef ENABLE_SPECTRUM_SHOW_CHANNEL_NAME
@@ -871,8 +871,10 @@ void BOARD_FactoryReset(bool bIsAll)
 	{
 		RADIO_InitInfo(gRxVfo, FREQ_CHANNEL_FIRST + BAND6_400MHz, 43350000);
 		gEeprom.RX_OFFSET = 0;
-		gEeprom.POWER_ON_PASSWORD = PASSWORD_OFF;
-		gEeprom.PASSWORD_WRONG_ATTEMPTS = 0;
+		#ifdef ENABLE_PWRON_PASSWORD
+			gEeprom.POWER_ON_PASSWORD = PASSWORD_OFF;
+			gEeprom.PASSWORD_WRONG_ATTEMPTS = 0;
+		#endif
 		SETTINGS_SaveSettings();
 		// set the first few memory channels
 		for (i = 0; i < ARRAY_SIZE(gDefaultFrequencyTable); i++)

--- a/settings.c
+++ b/settings.c
@@ -99,7 +99,7 @@ void SETTINGS_SaveSettings(void)
 	State[6] = gEeprom.AUTO_KEYPAD_LOCK;
 	State[7] = gEeprom.POWER_ON_DISPLAY_MODE;
 	EEPROM_WriteBuffer(0x0E90, State, true);
-	
+
 	// 0x0E98..0x0E9F
 	memset(State, 0xFF, sizeof(State));
 	EEPROM_ReadBuffer(0x0E98, State, 8);
@@ -114,12 +114,14 @@ void SETTINGS_SaveSettings(void)
 		State[0] = gEeprom.VOX_DELAY;
 	#endif
 	State[1] = gEeprom.RX_AGC;
-	State[2] = gEeprom.PASSWORD_WRONG_ATTEMPTS;
+	#ifdef ENABLE_PWRON_PASSWORD
+		State[2] = gEeprom.PASSWORD_WRONG_ATTEMPTS;
+	#endif
 	#ifdef ENABLE_MESSENGER
 		State[3] = gEeprom.MESSENGER_CONFIG.__val;
 	#endif
 	EEPROM_WriteBuffer(0x0EA0, State, true);
-	
+
 	memset(State, 0xFF, sizeof(State));
 	#if defined(ENABLE_ALARM) || defined(ENABLE_TX1750)
 		State[0] = gEeprom.ALARM_MODE;
@@ -139,7 +141,7 @@ void SETTINGS_SaveSettings(void)
 	State[2] = gEeprom.DTMF_GROUP_CALL_CODE;
 	State[3] = gEeprom.DTMF_DECODE_RESPONSE;
 	State[4] = gEeprom.DTMF_auto_reset_time;
-#endif	
+#endif
 	State[5] = gEeprom.DTMF_PRELOAD_TIME / 10U;
 	State[6] = gEeprom.DTMF_FIRST_CODE_PERSIST_TIME / 10U;
 	State[7] = gEeprom.DTMF_HASH_CODE_PERSIST_TIME / 10U;
@@ -177,7 +179,7 @@ void SETTINGS_SaveSettings(void)
 	if (!gSetting_live_DTMF_decoder) State[7] &= ~(1u << 1);
 	State[7] = (State[7] & ~(3u << 2)) | ((gSetting_battery_text & 3u) << 2);
 	State[7] = (State[7] & ~(3u << 6)) | ((gSetting_backlight_on_tx_rx & 3u) << 6);
-	 
+
 	EEPROM_WriteBuffer(0x0F40, State, true);
 
 	#ifdef ENABLE_FMRADIO
@@ -226,7 +228,7 @@ void SETTINGS_SaveChannel(uint8_t Channel, uint8_t VFO, const VFO_Info_t *pVFO, 
 				| (pVFO->FrequencyReverse  << 0);
 			if(pVFO->CHANNEL_BANDWIDTH != BK4819_FILTER_BW_WIDE)
 				State[4] |= ((pVFO->CHANNEL_BANDWIDTH - 1) << 5);
-			State[5] = ((pVFO->DTMF_PTT_ID_TX_MODE & 7u) << 1) 
+			State[5] = ((pVFO->DTMF_PTT_ID_TX_MODE & 7u) << 1)
 #ifdef ENABLE_DTMF_CALLING
 				| ((pVFO->DTMF_DECODING_ENABLE & 1u) << 0)
 #endif
@@ -246,7 +248,7 @@ void SETTINGS_SaveChannel(uint8_t Channel, uint8_t VFO, const VFO_Info_t *pVFO, 
 				#else
 					if (Mode >= 3) {
 						SETTINGS_SaveChannelName(Channel, pVFO->Name);
-						
+
 						#ifdef ENABLE_SPECTRUM_SHOW_CHANNEL_NAME
 							//update channel names stored in memory
 							BOARD_gMR_LoadChannels();
@@ -280,7 +282,7 @@ void SETTINGS_SaveChannelName(uint8_t channel, const char * name)
 
 #ifdef ENABLE_ENCRYPTION
 void SETTINGS_SaveEncryptionKey()
-{	
+{
 	EEPROM_WriteBuffer(0x0F30, gEeprom.ENC_KEY, true);
 	EEPROM_WriteBuffer(0x0F38, gEeprom.ENC_KEY + 8, true);
 	gRecalculateEncKey = true;
@@ -293,9 +295,9 @@ void SETTINGS_FetchChannelName(char *s, const int channel)
 
 	if (s == NULL)
 		return;
-	
+
 	memset(s, 0, 11);  // 's' had better be large enough !
-	
+
 	if (channel < 0)
 		return;
 


### PR DESCRIPTION
When setting ENABLE_PWRON_PASSWORD to 0, there were compiler failures due to a few lintering references to gEeprom.POWER_ON_PASSWORD and gEeprom.PASSWORD_WRONG_ATTEMPTS. This pull request wraps those references in #ifdef directives. The net saving seems to be aroun 1kb when disabling this feature.

Apparently there is also a significant amount of trailing whtespace in the files, which my editor automatically removes, sorry about that. 