### PR TITLE
Implement backlight timeout in spectrum mode

### DIFF
--- a/app/spectrum.h
+++ b/app/spectrum.h
@@ -140,7 +140,7 @@ typedef struct SpectrumSettings {
   int dbMin;
   int dbMax;  
   ModulationMode_t modulationType;
-  bool backlightState;
+  bool backlightAlwaysOn;
   int scanList;
 } SpectrumSettings;
 


### PR DESCRIPTION
Change the backlight behavior in spectrum mode to be more in line with e.g. regular scan:

 - It will turn on and stay on while receiving
 - It will turn on when any button is pressed
 - It will turn off after the normal timeout when not receiving
 - The 8 button toggles "always on" mode in case you want to see the spectrum plot even when not receiving

This way the backlight is not burning battery all the time when you are scanning (unless you want it to be), but it allows you to see the frequency/channel as soon as something is received.

Love the spectrum channel scan feature, btw! Just wish it could deal with FM/AM channels in the same scanlist, and more than two scanlists would also be really nice. I have no idea if these additions would be at all realistic.