### PR TITLE
Reduce Chacha rounds from 20 --> 8

### DIFF
--- a/external/chacha/chacha.c
+++ b/external/chacha/chacha.c
@@ -141,7 +141,7 @@ chacha_encrypt_bytes(struct chacha_ctx *x,const unsigned char *m,unsigned char *
     x13 = j13;
     x14 = j14;
     x15 = j15;
-    for (i = 20;i > 0;i -= 2) {
+    for (i = 8;i > 0;i -= 2) {
       QUARTERROUND( x0, x4, x8,x12)
       QUARTERROUND( x1, x5, x9,x13)
       QUARTERROUND( x2, x6,x10,x14)


### PR DESCRIPTION
Reducing the rounds of Chacha used in the encryption/decryption scheme leads to a performance increase, at no real cost to security. Please see this paper if you are interested in more details on why Chacha8 is still secure: https://eprint.iacr.org/2019/1492.pdf
I think the sacrifice in security is worth it for the increased performance in a chip like this.